### PR TITLE
Allow X11 color methods using refinement interface 

### DIFF
--- a/lib/rainbow/presenter.rb
+++ b/lib/rainbow/presenter.rb
@@ -89,55 +89,14 @@ module Rainbow
 
     alias strike cross_out
 
-    def black
-      color(:black)
-    end
-
-    def red
-      color(:red)
-    end
-
-    def green
-      color(:green)
-    end
-
-    def yellow
-      color(:yellow)
-    end
-
-    def blue
-      color(:blue)
-    end
-
-    def magenta
-      color(:magenta)
-    end
-
-    def cyan
-      color(:cyan)
-    end
-
-    def white
-      color(:white)
-    end
-
-    # We take care of X11 color method call here.
-    # Such as #aqua, #ghostwhite.
-    def method_missing(method_name, *args)
-      if Color::X11Named.color_names.include?(method_name) && args.empty?
-        color(method_name)
-      else
-        super
-      end
-    end
-
-    def respond_to_missing?(method_name, *args)
-      Color::X11Named.color_names.include?(method_name) && args.empty? || super
+    # Define foreground named color methods eg #red and #tomato
+    (Color::Named.color_names | Color::X11Named.color_names).each do |name|
+      define_method(name) { color(name) }
     end
 
     private
 
-    def wrap_with_sgr(codes) #:nodoc:
+    def wrap_with_sgr(codes) # :nodoc:
       self.class.new(StringUtils.wrap_with_sgr(self, [*codes]))
     end
   end

--- a/spec/integration/refinement_spec.rb
+++ b/spec/integration/refinement_spec.rb
@@ -4,6 +4,7 @@ require 'rainbow'
 RSpec.describe 'Rainbow refinement' do
   before do
     require 'rainbow/refinement'
+    Rainbow.enabled = true
     
     class ScopeNotIncluded
       def self.red_hello
@@ -16,6 +17,10 @@ RSpec.describe 'Rainbow refinement' do
       def self.red_hello
         'hello'.red
       end
+
+      def self.tomato_hello
+        'hello'.tomato
+      end
     end
   end
 
@@ -27,6 +32,10 @@ RSpec.describe 'Rainbow refinement' do
 
   it 'is available when used' do
     expect(ScopeIncluded.red_hello).to eq(Rainbow('hello').red)
+  end
+
+  it 'provides X11 named color methods' do
+    expect(ScopeIncluded.tomato_hello).to eq(Rainbow('hello').tomato)
   end
 
   it 'respects disabled state' do


### PR DESCRIPTION
See issue #128. I used define_method for all the named color methods instead of method_missing, and added a spec for the issue.