### PR TITLE
Allow `enabled` option to be passed to `Rainbow.new`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased 
 
+- Allow `enabled` option to be passed to `Rainbow.new`
 - Development: Drop `rbx` section in Gemfile. No continued support effort for Rubinius. 
 
 ## 3.1.1 (2022-01-11)

--- a/README.markdown
+++ b/README.markdown
@@ -153,10 +153,8 @@ parts of your application you can get a new Rainbow wrapper instance for each
 of them and control the state of coloring during the runtime.
 
 ```ruby
-rainbow_one = Rainbow.new
+rainbow_one = Rainbow.new(false)
 rainbow_two = Rainbow.new
-
-rainbow_one.enabled = false
 
 Rainbow("hello").red          # => "\e[31mhello\e[0m" ("hello" if not on TTY)
 rainbow_one.wrap("hello").red # => "hello"

--- a/lib/rainbow.rb
+++ b/lib/rainbow.rb
@@ -3,8 +3,8 @@
 require_relative 'rainbow/global'
 
 module Rainbow
-  def self.new
-    Wrapper.new(global.enabled)
+  def self.new(enabled = global.enabled)
+    Wrapper.new(enabled)
   end
 
   self.enabled = false unless STDOUT.tty? && STDERR.tty?

--- a/spec/integration/instance_spec.rb
+++ b/spec/integration/instance_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe 'Custom Rainbow instance' do
     expect(rainbow.enabled).to eq(:nope)
   end
 
+  it 'can be initialized with a different enabled state' do
+    Rainbow.enabled = :yep
+    rainbow = Rainbow.new(false)
+    expect(rainbow.enabled).to eq(false)
+  end
+
   it 'wraps string with escape codes when enabled' do
     rainbow = Rainbow.new
     rainbow.enabled = true


### PR DESCRIPTION
Wrapper.new already allows this, so we simply have to pass it on.