### PR TITLE
[README] Document `Rainbow.uncolor` method

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -69,7 +69,7 @@ calls:
 Rainbow("hola!").blue.bright.underline
 ```
 
-The `Rainbow` module also provides an `uncolor` method for striping away any
+The `Rainbow` module also provides an `uncolor` method for stripping away any
 existing color or formatting. This may be handy for determining the visual
 length of strings.
 

--- a/README.markdown
+++ b/README.markdown
@@ -69,6 +69,18 @@ calls:
 Rainbow("hola!").blue.bright.underline
 ```
 
+The `Rainbow` module also provides an `uncolor` method for striping away any
+existing color or formatting. This may be handy for determining the visual
+length of strings.
+
+```ruby
+text = Rainbow("this is green!").green
+# => "\e[32mthis is green!\e[0m"
+
+Rainbow.uncolor(text)
+# => "this is green!"
+```
+
 ### Refinement
 
 If you want to use the Refinements version, you can:


### PR DESCRIPTION
I was looking for a way to determine the visual length of previously rainbow-ized strings. After some searching I came across exactly what I needed: https://github.com/ku1ik/rainbow/pull/54

I hope adding this section to the readme will make the method easier for others to find 😊